### PR TITLE
add --zip build option: dated zip archive of Markdown pages, zip_sitepath/zip_filename template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Build a static website from Markdown files.
 - `--root, -r <name>` - Website root directory name (needed for GitHub Pages hosting)
 - `--lunr` - Create lunr search index (requires npm and lunr to be installed)
 - `--commits` - Include Git commit messages and times in All Pages
+- `--zip` - Build a zip archive of the site's Markdown pages into the output, named `{repo-name}-{YYYY-MM-DD-HHMM}Z.zip`; themes can link to it via the `zip_sitepath` and `zip_filename` template variables
 
 **Examples:**
 ```shell
@@ -66,6 +67,9 @@ markpub build -i my-wiki -o my-wiki-site
 
 # Build with search
 markpub build -i my-wiki -o my-wiki-site --lunr
+
+# Build with a downloadable zip of the Markdown pages
+markpub build -i my-wiki -o my-wiki-site --zip
 
 # Build for GitHub Pages with Git history
 markpub build -i my-wiki -o my-wiki-site --root my-repo --commits

--- a/docs/MarkPub User Documentation.md
+++ b/docs/MarkPub User Documentation.md
@@ -133,6 +133,9 @@ Build options:
 - `--root`: Website root directory name
 - `--lunr`: Enable full-text search
 - `--commits`: Include Git commit information
+- `--zip`: Build a downloadable zip archive of the site's Markdown pages
+
+With `--zip`, every build writes a fresh archive of the published Markdown pages (unlisted pages excluded, sidebar included) into the output directory, named `{repo-name}-{YYYY-MM-DD-HHMM}Z.zip` — the repository name plus the UTC build time. The pages sit inside a single top-level directory named like the archive, so unzipping produces one dated folder, ready to open as an Obsidian vault. Because the filename is dated, themes should link to it with the `zip_sitepath` (site-absolute path) and `zip_filename` template variables, which are empty strings when `--zip` is not used.
 
 ### Search Functionality
 

--- a/src/markpub/markpub.py
+++ b/src/markpub/markpub.py
@@ -34,6 +34,7 @@ import time
 import traceback
 from urllib.parse import urlparse
 import yaml
+import zipfile
 
 # Markpub libraries and modules - mistletoe based Markdown to HTML conversion
 from mistletoe import Document
@@ -55,6 +56,21 @@ def git_forge_proper_name(git_edit_url):
         return forge_loc
     else:
         return forge_name
+
+# derive a repository name for zip archive naming;
+# use the git remote URL (the checkout directory name is not meaningful on CI
+# hosts), fall back to a slug of the config wiki_title
+def get_repo_name(dir_wiki, config):
+    try:
+        p = subprocess.run(["git", "-C", dir_wiki, "remote", "get-url", "origin"], capture_output=True, check=True)
+        remote_url = p.stdout.decode('utf-8').strip()
+        name = re.split(r'[/:]', remote_url.rstrip('/'))[-1].removesuffix('.git')
+        if name:
+            return name
+    except Exception:
+        logger.debug("no usable git remote; falling back to wiki_title for zip name")
+    slug = re.sub(r'[^A-Za-z0-9]+', '-', config.get('wiki_title') or 'wiki').strip('-').lower()
+    return slug or 'wiki'
 
 def markdown_convert(markdown_text, rootdir, fileroot, file_id, websiteroot):
     with MassiveWikiRenderer(rootdir=rootdir, fileroot=fileroot, wikilinks=wiki_pagelinks, file_id=file_id, websiteroot=websiteroot) as renderer:
@@ -177,6 +193,8 @@ def build_site(args):
             'sidebar_body': sidebar_body,
             'lunr_index_sitepath': lunr_index_sitepath,
             'lunr_posts_sitepath': lunr_posts_sitepath,
+            'zip_filename': zip_filename,
+            'zip_sitepath': zip_sitepath,
             'websiteroot': websiteroot,
         }
         # Merge common_args with any additional kwargs
@@ -229,6 +247,20 @@ def build_site(args):
         # needed to feed to themes
         lunr_index_sitepath = ''
         lunr_posts_sitepath = ''
+
+    # one timestamp for this build; used for zip archive name and page footers
+    build_datetime = datetime.datetime.now(datetime.UTC)
+
+    # set up zip_filename and zip_sitepath
+    if (args[0].zip):
+        zip_basename = f"{get_repo_name(dir_wiki, config)}-{build_datetime.strftime('%Y-%m-%d-%H%M')}Z"
+        zip_filename = f"{zip_basename}.zip" # needed for next two variables
+        zip_filepath = Path(dir_output) / zip_filename # local filesystem
+        zip_sitepath = f"{websiteroot}/{zip_filename}" # website
+    else:
+        # needed to feed to themes
+        zip_filename = ''
+        zip_sitepath = ''
 
     # render the wiki
     try:
@@ -302,7 +334,8 @@ def build_site(args):
         # render all the Markdown files
         logger.debug("copy wiki to output; render .md files to HTML")
         all_pages = []
-        build_time = datetime.datetime.now(datetime.UTC).strftime("%A, %B %d, %Y at %H:%M UTC")
+        zip_members = []
+        build_time = build_datetime.strftime("%A, %B %d, %Y at %H:%M UTC")
 
         if 'sidebar' in config:
             sidebar_body = sidebar_convert_markdown(Path(dir_wiki) / config['sidebar'], rootdir, args[0].input, websiteroot)
@@ -320,6 +353,9 @@ def build_site(args):
                 if front_matter is False:
                     print(f"NOTE: YAML syntax error in front matter of '{Path(file)}'")
                     front_matter = {}
+                # remember page for --zip archive; skip unlisted pages
+                if args[0].zip and not front_matter.get('unlisted'):
+                    zip_members.append(file)
                 # output JSON of front matter
                 (Path(dir_output+clean_filepath).with_suffix(".json")).write_text(json.dumps(front_matter, indent=2, default=datetime_date_serializer))
                 # render and output HTML (empty edit_url on README and Sidebar pages)
@@ -368,6 +404,15 @@ def build_site(args):
             logger.debug("Copy all original files")
             logger.debug("%s -->  %s",Path(file), Path(dir_output+clean_filepath))
             shutil.copy(Path(file), Path(dir_output+clean_filepath))
+
+        # build zip archive of the site's Markdown pages if --zip
+        if (args[0].zip):
+            logger.debug("building zip archive: %s", zip_filepath)
+            if sidebar_file is not None and (Path(dir_wiki) / sidebar_file).exists():
+                zip_members.append((Path(dir_wiki) / sidebar_file).as_posix())
+            with zipfile.ZipFile(zip_filepath, 'w', compression=zipfile.ZIP_DEFLATED) as zip_archive:
+                for file in zip_members:
+                    zip_archive.write(file, f"{zip_basename}/{Path(file).relative_to(dir_wiki).as_posix()}")
 
         # build Lunr search index if --lunr
         if (args[0].lunr):
@@ -548,6 +593,7 @@ def main():
     parser_build.add_argument('--root', '-r', default='', help='name for website root directory (to host GitHub Pages)')
     parser_build.add_argument('--lunr', action='store_true', help='include this to create lunr index (requires npm and lunr to be installed, read docs)')
     parser_build.add_argument('--commits', action='store_true', help='include this to read Git commit messages and times, for All Pages')
+    parser_build.add_argument('--zip', action='store_true', help='include this to build a zip archive of the Markdown pages, downloadable from the website')
     parser_build.set_defaults(cmd='build')
 
     args = parser.parse_known_args()

--- a/tests/test_markpub.py
+++ b/tests/test_markpub.py
@@ -3,6 +3,9 @@
 import subprocess
 import pytest
 import filecmp
+import re
+import shutil
+import zipfile
 
 import logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -50,3 +53,42 @@ def run_and_verify():
 
 def test_compare_output_with_baseline(run_and_verify):
     assert compare_markpub_directories("tests/test-output/", "tests/baseline/"), "Directory contents do not match."
+
+def test_zip_build(tmp_path):
+    """
+    Builds with --zip from a copy of the fixture wiki (plus an unlisted page)
+    and verifies the zip archive: dated filename, single top-level directory,
+    contents equal to the published Markdown pages (sidebar included,
+    unlisted pages excluded).
+    """
+    wiki = tmp_path / "test-input"
+    shutil.copytree("tests/test-input", wiki)
+    (wiki / "Unlisted Test Page.md").write_text("---\nunlisted: true\n---\n\nRendered but not collected.\n")
+    output = tmp_path / "output"
+    cmd = [
+        "markpub",
+        "build",
+        "-c", str(wiki / ".markpub" / "markpub.yaml"),
+        "-i", str(wiki),
+        "-o", str(output),
+        "--zip",
+    ]
+    subprocess.run(cmd, check=True)
+
+    zips = list(output.glob("*.zip"))
+    assert len(zips) == 1, "expected exactly one zip archive in output"
+    # dated filename: {repo-name}-{YYYY-MM-DD-HHMM}Z.zip; the copied wiki has
+    # no git remote, so the repo name falls back to slugified wiki_title
+    assert re.fullmatch(r"markpub-test-website-\d{4}-\d{2}-\d{2}-\d{4}Z\.zip", zips[0].name)
+
+    basename = zips[0].name.removesuffix(".zip")
+    with zipfile.ZipFile(zips[0]) as zip_archive:
+        names = zip_archive.namelist()
+    assert names and all(n.startswith(f"{basename}/") for n in names), "all members must be inside one top-level directory named like the zip"
+
+    expected = {
+        p.relative_to(wiki).as_posix()
+        for p in wiki.rglob("*.md")
+        if not any(part.startswith(".") for part in p.relative_to(wiki).parts)
+    } - {"Unlisted Test Page.md"}
+    assert {n.removeprefix(f"{basename}/") for n in names} == expected


### PR DESCRIPTION
Fixes #34.

Adds a `--zip` option to `markpub build` that packages the site's Markdown pages into a downloadable zip archive, replacing the by-hand zip step some MarkPub sites have used (the OGM call wikis' `zip [repo-name].zip *.md` convention).

**Behavior:**

- The archive contains the Markdown pages the build publishes — the same discovered file list the build already uses, so `excluded_directories` and dotfile exclusion are respected — plus the sidebar file. Pages with `unlisted: true` front matter are excluded (composes with #33 in either merge order; the check is a local `front_matter.get('unlisted')` on the already-parsed front matter).
- Filename: `{repo-name}-{YYYY-MM-DD-HHMM}Z.zip` (UTC build time, colon-free so it's Windows-safe), e.g. `ogm-2026-04-16-2026-07-26-1410Z.zip`. The repo name derives from `git remote get-url origin` — the checkout directory name is meaningless on CI hosts — falling back to a slugified `wiki_title` for remoteless directories.
- Contents sit inside a single top-level directory named like the zip basename, so unzipping produces one dated folder, ready to open as an Obsidian vault.
- Written into the output directory root on every build — always fresh.
- Two template variables join the common context exactly like `lunr_index_sitepath`: `zip_sitepath` (site-absolute, `websiteroot`-prefixed) and `zip_filename`, both `''` when `--zip` is off, so themes can guard with a plain `{% if zip_sitepath %}`.

Since the filename is dated, the template variable is the link mechanism (hand-written links can't stay correct), same as with the timestamped lunr files. Companion PR to markpub-themes adds the visible link to dolce's footer: markpub/markpub-themes#1.

**Also in this PR:** a `test_zip_build` pytest that builds a copy of the fixture wiki (plus an added `unlisted: true` page) with `--zip` into a temp directory and verifies the dated filename, the single top-level directory, and that the member list equals the published Markdown set. The fixture's hostile filenames (commas, quotes, `%`) get exercised for free. README and User Documentation updated.

**Verified against a real site:** built `ogm-2026-04-16` with `--zip` and the patched dolce — correct dated archive (72 pages, markdown-only, sidebar included), footer link renders when `--zip` is on and is absent when off. `ruff check` clean.

**Noticed while testing, not addressed here:** `test_compare_output_with_baseline` currently fails on a clean `main` checkout — the committed baseline predates the current markpub-themes dolce (`markpub-static` vs `markpub_static` static dir, plus HTML drift), so the golden baseline needs regenerating. Also, the existing test still passes a `-t` flag the CLI no longer accepts (silently swallowed by `parse_known_args`). Both feel like #29 material.

🤖 Drafted by Saga (Claude) under Pete's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
